### PR TITLE
Changing HudScale from pause menu works now 

### DIFF
--- a/ClockLib/ClockLib.csproj
+++ b/ClockLib/ClockLib.csproj
@@ -116,19 +116,19 @@
       rmdir /s /q "$(OwmlDir)\Mods\$(ModUniqueName)"
       md "$(OwmlDir)\Mods\$(ModUniqueName)"
       copy /y "$(TargetPath)" "$(OwmlDir)\Mods\$(ModUniqueName)"
-      copy /y "$(ProjectDir)\default-config.json" "$(OwmlDir)\Mods\$(ModUniqueName)"
-      copy /y "$(ProjectDir)\manifest.json" "$(OwmlDir)\Mods\$(ModUniqueName)"
-      copy /y "$(ProjectDir)\events.json" "$(OwmlDir)\Mods\$(ModUniqueName)"
+      copy /y "$(ProjectDir)default-config.json" "$(OwmlDir)\Mods\$(ModUniqueName)"
+      copy /y "$(ProjectDir)manifest.json" "$(OwmlDir)\Mods\$(ModUniqueName)"
+      copy /y "$(ProjectDir)events.json" "$(OwmlDir)\Mods\$(ModUniqueName)"
 
-      md "$(ProjectDir)\Release"
-      copy /y "$(ProjectDir)\default-config.json" "$(ProjectDir)\Release"
-      copy /y "$(ProjectDir)\manifest.json" "$(ProjectDir)\Release"
-      copy /y "$(ProjectDir)\events.json" "$(ProjectDir)\Release"
-      copy /y "$(ProjectDir)\bin\Release\Clock.dll" "$(ProjectDir)\Release"
+      md "$(ProjectDir)Release"
+      copy /y "$(ProjectDir)default-config.json" "$(ProjectDir)Release"
+      copy /y "$(ProjectDir)manifest.json" "$(ProjectDir)Release"
+      copy /y "$(ProjectDir)events.json" "$(ProjectDir)Release"
+      copy /y "$(ProjectDir)bin\Release\Clock.dll" "$(ProjectDir)Release"
       cd "$(ProjectDir)"
       tar.exe -a -c -f Release.zip "Release"
       rmdir /s /q "$(ProjectDir)\Release"
-    </PostBuildEvent>
+</PostBuildEvent>
   </PropertyGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/ClockLib/ClockLib.csproj.user
+++ b/ClockLib/ClockLib.csproj.user
@@ -2,8 +2,8 @@
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectView>ProjectFiles</ProjectView>
-    <GameDir>E:\Program Files\Epic Games\OuterWilds</GameDir>
-    <OwmlDir>C:\Users\Jamie\AppData\Roaming\OuterWildsModManager\OWML</OwmlDir>
-    <ModUniqueName>OWClock</ModUniqueName>
+    <GameDir>C:\Program Files (x86)\Steam\steamapps\common\Outer Wilds</GameDir>
+    <OwmlDir>%appdata%\OuterWildsModManager\OWML</OwmlDir>
+    <ModUniqueName>clubby789.OWClock</ModUniqueName>
   </PropertyGroup>
 </Project>

--- a/ClockLib/OWClock.cs
+++ b/ClockLib/OWClock.cs
@@ -3,6 +3,7 @@ using OWML.Common.Menus;
 using OWML.ModHelper;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace Clock
@@ -10,12 +11,13 @@ namespace Clock
     public class OWClock : ModBehaviour
     {
         private static EventFile _save;
-        private readonly List<string> _eventListStr = new List<string>();
-        private readonly List<KeyValuePair<float, string>> _eventList = new List<KeyValuePair<float, string>>();
+        private List<TimeEvent> _eventList;
         private Font _hudFont;
         private float _xPos;
         private float _yPos;
         private float _width;
+        private int _displayHeight;
+        private int _displayWidth;
 
         internal static IModHelper Helper;
         public static bool CountUp { get; private set; }
@@ -25,43 +27,34 @@ namespace Clock
         public static List<int> EnabledTypes { get; private set; } = new List<int>();
         public static EventFile Save { get => _save; set => _save = value; }
 
+        #region "Magic methods from Unity MonoBehaviour"
+#pragma warning disable IDE0051 // Remove unused private members
+        /// <summary>
+        /// Called once when the mod is loaded
+        /// </summary>
         private void Start()
+#pragma warning restore IDE0051 // Remove unused private members
         {
             Helper = ModHelper;
             Save = EventFile.LoadSaveFile();
             _hudFont = Resources.Load<Font>(@"fonts/english - latin/SpaceMono-Regular_Dynamic");
             ModHelper.Menus.PauseMenu.OnInit += AddMenuItem;
 
-            ModHelper.Console.WriteLine($"My mod {nameof(Clock)} is loaded!", MessageType.Success);
+            ModHelper.Console.WriteLine($"OWClock mod loaded at " + DateTime.Now.ToString("s"), MessageType.Success);
 
-            GlobalMessenger<GraphicSettings>.AddListener("GraphicSettingsUpdated", RecalculatePosition);
+            GlobalMessenger<GraphicSettings>.AddListener("GraphicSettingsUpdated", GetDisplaySettings);
+
+            // We need the wake event to reload our eventlist because we are going to remove expired items from the list as they pass.
+            ModHelper.Events.Subscribe<PlayerBody>(Events.AfterAwake);
+            ModHelper.Events.Event += OnEvent;
         }
 
-        private void AddMenuItem()
-        {
-            var eventMenu = ModHelper.Menus.PauseMenu.Copy("ADD EVENT");
-            var openInputButton = ModHelper.Menus.PauseMenu.ResumeButton.Duplicate("ADD EVENT");
-            openInputButton.OnClick += EventPopup;
-
-            var eventMenu2 = ModHelper.Menus.PauseMenu.Copy("DEBUG TIME");
-            var openInputButton2 = ModHelper.Menus.PauseMenu.ResumeButton.Duplicate("DEBUG TIME");
-            openInputButton2.OnClick += LogTime;
-        }
-
-        private void LogTime()
-        {
-            var currentTime = TimeLoop.GetSecondsElapsed();
-            ModHelper.Console.WriteLine($"Time is {currentTime}");
-        }
-
-        private void RecalculatePosition(GraphicSettings settings)
-        {
-            _yPos = settings.displayResHeight - 60f;
-            _xPos = Milliseconds ? settings.displayResWidth * (1-HudScale/100) - 80f : settings.displayResWidth * (1 - HudScale / 100) - 20f;
-            _width = settings.displayResWidth * (HudScale/100);
-        }
-
+#pragma warning disable IDE0051 // Remove unused private members
+        /// <summary>
+        /// OnGUI is called for rendering and handling GUI events by Unity. 
+        /// </summary>
         private void OnGUI()
+#pragma warning restore IDE0051 // Remove unused private members
         {
             if (GUIMode.IsHiddenMode() || PlayerState.UsingShipComputer())
             {
@@ -88,14 +81,17 @@ namespace Clock
 
             style.fontSize = 20;
             int shown = 0;
+
             // Loop until desired number of events are shown
             // OR we reach end of list
             float yOff = 0;
-            for (int i = 0; (i < Save.eventList.Count) && (shown < EventCount); i++)
+            for (int i = 0; (i < _eventList.Count) && (shown < EventCount); i++)
             {
-                var timeEvent = Save.eventList[i];
+                var timeEvent = _eventList[i];
                 if (timeEvent.Timestamp < elapsed)
                 {
+                    // If the event has passed we should stop looking at it.
+                    _eventList.RemoveAt(i);
                     continue;
                 }
 
@@ -110,35 +106,15 @@ namespace Clock
                 GUIContent guiText = new GUIContent($"{timeString} - {timeEvent.Name}");
                 float labelSize = style.CalcHeight(guiText, _width);
                 yOff += labelSize;
-                GUI.Label(new Rect(_xPos, _yPos - yOff, _width, labelSize), $"{timeString} - {timeEvent.Name}", style);
+                GUI.Label(new Rect(_xPos, _yPos - yOff, _width, labelSize), guiText, style);
                 shown++;
             }
         }
 
-        private void EventPopup()
-        {
-            var popup = ModHelper.Menus.PopupManager.CreateInputPopup(InputType.Text, "Event Name");
-            popup.OnConfirm += AddEvent;
-        }
-
-        private void AddEvent(string text)
-        {
-            Save.AddEvent(TimeLoop.GetSecondsElapsed(), text);
-        }
-
-        static string ParseTime(float timestamp)
-        {
-            var minutes = Mathf.Floor(timestamp / 60f).ToString().PadLeft(2, '0');
-            var seconds = Math.Truncate(timestamp % 60f).ToString().PadLeft(2, '0');
-            var clock = $"{minutes}:{seconds}";
-            if (Milliseconds)
-            {
-                var milliseconds = Math.Truncate((timestamp - Math.Floor(timestamp)) * 1000).ToString().PadLeft(3, '0');
-                clock = $"{clock}.{milliseconds}";
-            }
-            return clock;
-        }
-
+        /// <summary>
+        /// Called by OWML; once at the start and upon each config setting change.
+        /// </summary>
+        /// <param name="config">The new settings passed from OWML</param>
         public override void Configure(IModConfig config)
         {
             CountUp = config.GetSettingsValue<bool>("Count Up");
@@ -153,7 +129,114 @@ namespace Clock
                 {
                     EnabledTypes.Add(i);
                 }
-            }          
+            }
+
+            // When the HudScale changes, we need to scale the HUD
+            RecalculatePosition();
+        }
+
+        #endregion
+
+        #region "Event Handlers"
+        /// <summary>
+        /// Handles all ModHelper.Events you Subscribe to.
+        /// </summary>
+        /// <param name="behaviour">From UnityEngine.CoreModule</param>
+        /// <param name="ev">The event that is happening.</param>
+        private void OnEvent(MonoBehaviour behaviour, Events ev)
+        {
+            ModHelper.Console.WriteLine("Behaviour name: " + behaviour.name);
+
+            // Start the list over from the save file when you wake up. This allows us to remove events as they happen.
+            if (behaviour.GetType() == typeof(PlayerBody) && ev == Events.AfterAwake)
+            {
+                ModHelper.Console.WriteLine("Loading the event list for the clock.");
+                _eventList = Save.eventList.ToList();
+            }
+        }
+
+        /// <summary>
+        /// Adds custom menu items to the game.
+        /// </summary>
+        private void AddMenuItem()
+        {
+            var addEventMenu = ModHelper.Menus.PauseMenu.Copy("ADD EVENT");
+            var addEventInputButton = ModHelper.Menus.PauseMenu.ResumeButton.Duplicate("ADD EVENT");
+            addEventInputButton.OnClick += EventPopup;
+
+            var debugEventMenu = ModHelper.Menus.PauseMenu.Copy("DEBUG TIME");
+            var debugEventInputButton = ModHelper.Menus.PauseMenu.ResumeButton.Duplicate("DEBUG TIME");
+            debugEventInputButton.OnClick += LogTime;
+        }
+
+        /// <summary>
+        /// Print the current time to the OWML log window.
+        /// </summary>
+        private void LogTime()
+        {
+            var currentTime = TimeLoop.GetSecondsElapsed();
+            ModHelper.Console.WriteLine($"Time is {currentTime}");
+        }
+
+        /// <summary>
+        /// Handles the GraphicSettingsUpdated event from Unity.
+        /// </summary>
+        /// <param name="settings">The settings passed from Unity.</param>
+        private void GetDisplaySettings(GraphicSettings settings)
+        {
+            // Store the current resolution so we can update our position based on changes to HudScale later.
+            _displayHeight = settings.displayResHeight;
+            _displayWidth = settings.displayResWidth;
+            RecalculatePosition();
+        }
+
+        /// <summary>
+        /// Get user input for the menu item "ADD EVENT".
+        /// </summary>
+        private void EventPopup()
+        {
+            var popup = ModHelper.Menus.PopupManager.CreateInputPopup(InputType.Text, "Event Name");
+            popup.OnConfirm += AddEvent;
+        }
+
+        /// <summary>
+        /// Save the new event that the user created from the menu.
+        /// </summary>
+        /// <param name="text">Name of the event.</param>
+        private void AddEvent(string text)
+        {
+            Save.AddEvent(TimeLoop.GetSecondsElapsed(), text);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Determine where the Time events and clock should be positioned in the HUD.
+        /// </summary>
+        private void RecalculatePosition()
+        {
+            _yPos = _displayHeight - 60f;
+            _xPos = Milliseconds ? _displayWidth * (1 - HudScale / 100) - 80f : _displayWidth * (1 - HudScale / 100) - 20f;
+            _width = _displayWidth * (HudScale / 100);
+        }
+
+        /// <summary>
+        /// Format for the clock.
+        /// </summary>
+        /// <param name="timestamp">From TimeLoop.GetSecondsElapsed</param>
+        /// <returns>The clock display in string format, ready to be put on a GUI.Label</returns>
+        static string ParseTime(float timestamp)
+        {
+            var minutes = Mathf.Floor(timestamp / 60f).ToString().PadLeft(2, '0');
+            var seconds = Math.Truncate(timestamp % 60f).ToString().PadLeft(2, '0');
+            var clock = $"{minutes}:{seconds}";
+            if (Milliseconds)
+            {
+                var milliseconds = Math.Truncate((timestamp - Math.Floor(timestamp)) * 1000).ToString().PadLeft(3, '0');
+                clock = $"{clock}.{milliseconds}";
+            }
+
+            return clock;
         }
     }
 }

--- a/ClockLib/Properties/AssemblyInfo.cs
+++ b/ClockLib/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Resources;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -31,5 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.5.0.0")]
-[assembly: AssemblyFileVersion("0.5.0.0")]
+[assembly: AssemblyVersion("0.6.1.0")]
+[assembly: AssemblyFileVersion("0.6.1.0")]
+[assembly: NeutralResourcesLanguage("en-US")]

--- a/ClockLib/manifest.json
+++ b/ClockLib/manifest.json
@@ -4,6 +4,6 @@
   "name": "Clock",
   "uniqueName": "clubby789.OWClock",
   "description": "Adds a clock overlay and eventlist",
-  "version": "0.5.0",
+  "version": "0.6.1",
   "owmlVersion": "2.1.0"
 }


### PR DESCRIPTION
Closes #7
It might help with #4 too because the RecalculatePosition  is called every time settings are changed now.
Remove redundant `\` from build event.
OwmlDir can be dynamic with %appdata%
Make UniqueName match.
Remove events from list when they have passed (Should improve performance slightly)
RecalculatePosition from Configure to fix HudScale.
Add comments.
Organize code blocks.